### PR TITLE
Use libfltk-dev (build) and fluid (run) instead of fltk

### DIFF
--- a/indigo/package.xml
+++ b/indigo/package.xml
@@ -29,14 +29,14 @@
   <buildtool_depend>pkg-config</buildtool_depend>
 
   <build_depend>gtk2</build_depend>
-  <build_depend>fltk</build_depend>
+  <build_depend>libfltk-dev</build_depend>
   <build_depend>libjpeg</build_depend>
   <build_depend>libtool</build_depend>
   <build_depend>opengl</build_depend>
 
   <run_depend>catkin</run_depend>
   <run_depend>gtk2</run_depend>
-  <run_depend>fltk</run_depend>
+  <run_depend>fluid</run_depend>
   <run_depend>libjpeg</run_depend>
   <run_depend>opengl</run_depend>
 


### PR DESCRIPTION
As suggested by @tfoote, see [this comment](https://github.com/ros/rosdistro/pull/7377#issue-59115158)
The same thing was done for stage_ros: https://github.com/ros-simulation/stage_ros/commit/b9cf9a4d01a48837d407f579259c8ae25bcc075f