### PR TITLE
Remove fluid from run_depends (1/3)

### DIFF
--- a/indigo/package.xml
+++ b/indigo/package.xml
@@ -36,7 +36,6 @@
 
   <run_depend>catkin</run_depend>
   <run_depend>gtk2</run_depend>
-  <run_depend>fluid</run_depend>
   <run_depend>libjpeg</run_depend>
   <run_depend>opengl</run_depend>
 

--- a/jade/package.xml
+++ b/jade/package.xml
@@ -36,7 +36,6 @@
 
   <run_depend>catkin</run_depend>
   <run_depend>gtk2</run_depend>
-  <run_depend>fluid</run_depend>
   <run_depend>libjpeg</run_depend>
   <run_depend>opengl</run_depend>
 


### PR DESCRIPTION
In Ubuntu, `libfltk-dev` has a dependency on `fluid`. In Fedora, it does not, and without it the build fails like so:
```
CMake Error at /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:136 (message):
  Could NOT find FLTK (missing: FLTK_FLUID_EXECUTABLE)
Call Stack (most recent call first):
  /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:343 (_FPHSA_FAILURE_MESSAGE)
  /usr/share/cmake/Modules/FindFLTK.cmake:320 (FIND_PACKAGE_HANDLE_STANDARD_ARGS)
  CMakeLists.txt:105 (find_package)


-- Configuring incomplete, errors occurred!
```

This breaks all Fedora builds (Indigo/Jade, Fedora 20/21/22)

Regression caused by 2d5efe669feee6e491085e88c3847d43933a8e05

Example build break: http://csc.mcs.sdsmt.edu/jenkins/job/ros-jade-stage_binaryrpm_21_x86_64/1/consoleFull

Thanks,

--scott