### PR TITLE
Add libfltk-dev to run_depends

### DIFF
--- a/indigo/package.xml
+++ b/indigo/package.xml
@@ -35,6 +35,7 @@
   <build_depend>opengl</build_depend>
 
   <run_depend>catkin</run_depend>
+  <run_depend>libfltk-dev</run_depend>
   <run_depend>gtk2</run_depend>
   <run_depend>libjpeg</run_depend>
   <run_depend>opengl</run_depend>

--- a/jade/package.xml
+++ b/jade/package.xml
@@ -35,6 +35,7 @@
   <build_depend>opengl</build_depend>
 
   <run_depend>catkin</run_depend>
+  <run_depend>libfltk-dev</run_depend>
   <run_depend>gtk2</run_depend>
   <run_depend>libjpeg</run_depend>
   <run_depend>opengl</run_depend>


### PR DESCRIPTION
Ensures `libfltk-dev` is installed for downstream packages

See: https://github.com/ros-simulation/stage_ros/issues/14#issuecomment-138040081
